### PR TITLE
Typo e aggiunti passaggi

### DIFF
--- a/iii/funzioni-implicite.tex
+++ b/iii/funzioni-implicite.tex
@@ -123,7 +123,7 @@ La condizione è ovviamente soltanto sufficiente.
 \end{definizione}
 Il seguente teorema mostra una condizione sufficiente a determinare se una funzione è un diffeomorfismo locale.
 \begin{teorema}[di invertibilità locale] \label{t:invertibilita-locale}
-	Siano $A,B$ due insiemi aperti di $\R^n$, $\vec x_0$ un punto di $A$, e $\vec f$ una funzione da $A$ a $B$.
+	Siano $A,B$ due insiemi aperti di $\R^n$, $\vec x_0$ un punto di $A$, e $\vec f$ una funzione da $A$ a $B$ di classe $\cont{1}(A)$.
 	La funzione $\vec f$ è un diffeomorfismo locale in $\vec x_0$ se la matrice jacobiana in tale punto non è singolare, cioè se
 	\begin{equation} 
 		\det\jac\vec f(\vec x_0)\neq 0.
@@ -148,7 +148,7 @@ Il seguente teorema mostra una condizione sufficiente a determinare se una funzi
 		\label{eq:vettori-ortogonali-diffeomorfismo}
 	\end{equation}
 	Chiamiamo $\vec v_n$ il vettore $\vec x_n-\tilde{\vec x}_n$ normalizzato: esso ha norma 1, dunque appartiene alla sfera $n$ dimensionale $S^{n-1}\subset\R^n$.\footnote{Si distingue in matematica tra la \emph{sfera}, che è la superficie chiusa $n$-dimensionale immersa in $\R^{n+1}$, e la \emph{palla} che è l'insieme la cui frontiera è la sfera, cioè comprende anche i punti interni. La sfera in $\R^n$ è indicata spesso con $S^{n-1}$.}
-	Essa è un insieme compatto dunque $\vec v_n$, che è una successione in esso contenuta, deve convergere ad un elemento di $S^{n-1}$.
+	Essa è un insieme compatto dunque $\vec v_n$, che è una successione in esso contenuta, deve convergere ad un elemento di $S^{n-1}$, che indichiamo con $\vec v$.
 	Allora $\scalar{\grad f(\vxi_i)}{\vec v}=0$ per ogni $i$, vale a dire $\jac\vec f(\vec x_0)\vec v=\vec 0$.
 	Questo però è assurdo, poiché $\vec v$ non è nullo e $\det\jac\vec f(\vec x_0)\neq 0$.
 	Allora $\vec f$ deve essere iniettiva\footnote{Poiché $\det\jac\vec f(\vec x_0)\neq 0$, essa individua un operatore lineare iniettivo, ossia $\ker\jac\vec f(\vec x_0)=\{\vec 0\}$, quindi l'unico vettore che può dare il vettore nullo è solo il vettore nullo stesso (e $\vec v$ non lo è!).}.
@@ -161,7 +161,7 @@ Il seguente teorema mostra una condizione sufficiente a determinare se una funzi
 		\det\jac\vec F(\vec x_0,\vec y_0)=-\det\jac\vec f(\vec x_0),
 	\end{equation}
 	che non è nullo per quanto detto nella prima parte della dimostrazione.
-	Possiamo allora applicare il teorema di Dini per una funzione implicita $\vec x=\vphi(\vec y)$: esso afferma che esiste un intorno $V$ di $\vec y_0$ tale che esiste una funzione $\vphi\colon V\to W$ di classe $\cont{1}(V)$ per cui vale $\vec F(\vphi(\vec y),\vec y)=\vec 0$ per ogni $\vec v\in V$.
+	Possiamo allora applicare il teorema di Dini per una funzione implicita $\vec x=\vphi(\vec y)$: esso afferma che esiste un intorno $V$ di $\vec y_0$ tale che esiste una funzione $\vphi\colon V\to W$ di classe $\cont{1}(V)$ per cui vale $\vec F(\vphi(\vec y),\vec y)=\vec 0$ per ogni $\vec y\in V$.
 	Allora, se esiste una funzione inversa di $\vec f$, essa deve essere proprio $\vphi$, perch\'e $\vec y=\vec f\big(\vphi(\vec y)\big)$, cioè $\vec y=\vec f\circ \vphi(\vec y)$.
 	Dimostriamo quindi che l'inversa di $\vec f$ esiste: prendiamo l'intorno $W$ di $\vec x_0$ e la controimmagine in $\vec f$ di $V$, e chiamiamo $U\defeq W\cap\vec f^{-1}(V)$.
 	Per tale insieme vale $\vec f(\vec x)=\vec y\in V$, quindi
@@ -173,7 +173,8 @@ Il seguente teorema mostra una condizione sufficiente a determinare se una funzi
 \end{proof}
 Anche qui possiamo affermare qualcosa sulle derivate: $\jac\vphi(\vec y)=\jac\vec f^{-1}(\vec y)$, e con il teorema \ref{t:dini-Rn} di Dini troviamo che
 \begin{equation}
-	\jac\vec f^{-1}(\vec y)=\bigg[\drp{\vec F}{\vec x}\big(\vec f^{-1}(\vec y)\big)\bigg]^{-1}\cdot I.
+	\jac\vec f^{-1}(\vec y)=-\bigg[-\drp{\vec f}{\vec x}\big(\vec f^{-1}(\vec y)\big)\bigg]^{-1}\cdot\drp{\vec F}{\vec y}\big(\vec f^{-1}(\vec y),\vec y\big)=\\
+	=\bigg[\drp{\vec f}{\vec x}\big(\vec f^{-1}(\vec y)\big)\bigg]^{-1}\cdot I.
 \end{equation}
 Inoltre dato che $(\vec f^{-1}\circ\vec f)(\vec x)=\vec x$, le loro jacobiane sono tali per cui
 \begin{equation*}
@@ -184,7 +185,7 @@ come dovrebbe giustamente risultare.
 \section{Estremi vincolati}
 Prendiamo un insieme $K$ compatto di $\R^2$, e una funzione definita da esso a $\R$.
 Per il teorema di Weierstrass, se $f\in\cont{}(K)$, deve certamente assumere un massimo ed un minimo in $K$: possiamo distinguerli se si trovano nell'interno o sulla frontiera dell'insieme.
-Per i punti in $\mathring{K}$, dove $f$ è differenziabile il teorema di Fermat ci assicura che gli estremanti si trovano laddove $\grad f=\vec 0$.
+Per i punti in $\mathring{K}$, dove $f$ è differenziabile, il teorema di Fermat ci assicura che gli estremanti si trovano laddove $\grad f=\vec 0$.
 Sul bordo, però, ciò non è possibile. Trovandoci in $\R^2$, $\partial K$ è una curva di $\R^2$: supponiamo che essa sia regolare, data da una parametrizzazione lungo un intervallo $[a,b]$, cioè sia scrivibile come funzione $\vphi\colon[a,b]\to A\in\R^2$.
 Sia dunque $\vphi=\big(x(t),y(t)\big)$: l'insieme $\Phi=\{\vphi(t)\colon t\in[a,b]\}$ è detto \emph{sostegno} della curva $\vphi$.
 Restringiamo $f$ all'insieme $\Phi$ e cerchiamo in questo insieme gli estremi: risulta chiaramente che
@@ -240,13 +241,13 @@ Il seguente teorema mostra una condizione sufficiente ad individuare i punti \em
 	Ancora una volta si può interpretare come una relazione di ortogonalità tra il gradiente di $f$ nel punto $(x_0,y_0)=\big(x_0,h(x_0)\big)$ e il vettore $\big(1,h'(x_0)\big)^t$.
 	Abbiamo dunque che i gradienti di $f$ e $F$ nel punto sono ortogonali allo stesso vettore: ciò implica che essi sono proporzionali (hanno la stessa direzione), vale a dire $\grad f(x_0,y_0)=\lambda\grad F(x_0,y_0)$ per un certo numero $\lambda\in\R$.
 \end{proof}
-Il teorema appena dimostrato non si limita ovviamente alla funzioni in due variabili, ma si può generalizzare come di seguito.
+Il teorema appena dimostrato non si limita ovviamente alle funzioni in due variabili, ma si può generalizzare come di seguito.
 \begin{teorema}[dei moltiplicatori di Lagrange] \label{t:moltiplicatori-lagrange}
 	Sia $f\colon\Omega\to\R$, con $\Omega\in\R^n$ aperto e $f\in\cont{1}(\Omega)$. Sia inoltre $\vec F\colon\Omega\to\R^m$, con $m<n$, anch'essa di classe $\cont{1}(\Omega)$, e $E=\{\vec x\in\Omega\colon\vec F(\vec x)=\vec 0\}$.
 	Se $\vec x_0\in\Omega$ è un estremante di $f|_E$ e il rango della jacobiana $\jac\vec F(\vec x_0)$ è massimo, allora esiste un vettore $\vlambda\in\R^m$ tale che $(\vec x_0,\vlambda)\in\Omega\times\R^m$ è soluzione del sistema
 	\begin{equation} 
 		\begin{dcases}
-			\drp{f}{x_i}(\vec x)=\sum_{j=1}^m\lambda_j\drp{F_j}{x_i}\\
+			\drp{f}{x_i}(\vec x)=\sum_{j=1}^m\lambda_j\drp{F_j}{x_i}(\vec x)\\
 			\vec F(\vec x)=\vec 0
 		\end{dcases}
 		\label{eq:moltiplicatori-lagrange}


### PR DESCRIPTION
Aggiunti passaggi sulle conseguenze del teorema di invertibilità locale.
Corretti errori di digitazione.
(nessuna prova di compilazione eseguita, nessuna garanzia su sintassi e allineamento)
