### PR TITLE
Corretto rapporto di causalità su forme esatte

### DIFF
--- a/iii/forme-differenziali.tex
+++ b/iii/forme-differenziali.tex
@@ -312,7 +312,7 @@ Con queste definizioni possiamo quindi enunciare il seguente importante teorema.
 	Sia $A\subseteq\R^n$ un insieme aperto e semplicemente connesso, e $\omega$ una forma differenziale lineare di classe $\cont{1}(A)$.
 	Se $\omega$ è chiusa in $A$, allora è anche esatta in tale insieme.
 \end{teorema}
-La forma vista nell'esempio precedente non può essere esatta in $\R^2\setminus\{\vec 0\}$ perch\'e l'insieme non è semplicemente connesso: ogni curva che circonda l'origine non può essere deformata in un punto (dell'insieme) tramite un'omotopia, perch\'e abbiamo il ``buco'' nell'origine che lo impedisce.
+La forma vista nell'esempio precedente può non essere esatta in $\R^2\setminus\{\vec 0\}$ perch\'e l'insieme non è semplicemente connesso: ogni curva che circonda l'origine non può essere deformata in un punto (dell'insieme) tramite un'omotopia, perch\'e abbiamo il ``buco'' nell'origine che lo impedisce.
 Questo risultato è molto importante, perch\'e fornisce le condizioni meno restrittive per affermare l'esattezza della forma.
 La sua dimostrazione però è piuttosto complicata, e non la trattiamo: possiamo però verificarne la validità su insiemi più semplici, come gli insiemi cosiddetti \emph{stellati} o gli insiemi convessi, che sono tutti semplicemente connessi quindi per le forme in tali insiemi vale il lemma di Poincar\'e.
 \begin{definizione} \label{d:insieme-stellato}


### PR DESCRIPTION
Il lemma afferma che se l'insieme è semplicemente connesso allora una forma chiusa è anche esatta, ma non il viceversa.
